### PR TITLE
Adding `GetOpts` config option `pass_through`

### DIFF
--- a/archdiff
+++ b/archdiff
@@ -23,7 +23,7 @@ sub run_archdiff {
 
     my %opts;
 
-    Getopt::Long::Configure("no_auto_abbrev");
+    Getopt::Long::Configure("no_auto_abbrev", "pass_through");
     GetOptionsFromArray( \@argv, \%opts, 'verbose|v', 'quiet|q', 'help|h|?',
         'no-autostrip|n', 'version' );
 


### PR DESCRIPTION
Adding `pass_through` to `Getopt::Long::Configure` to actually pass along the diff switched tacked on to the end of the arguments list.